### PR TITLE
Fix fov calculation with lagging or high fps

### DIFF
--- a/src/main/java/dev/isxander/zoomify/mixins/GameRendererMixin.java
+++ b/src/main/java/dev/isxander/zoomify/mixins/GameRendererMixin.java
@@ -2,15 +2,21 @@ package dev.isxander.zoomify.mixins;
 
 import dev.isxander.zoomify.Zoomify;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.GameRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.text.MessageFormat;
 
 @Mixin(GameRenderer.class)
 public class GameRendererMixin {
-    @ModifyVariable(method = "getFov", at = @At(value = "RETURN", shift = At.Shift.BEFORE), ordinal = 0)
-    private double getFov(double fov) {
-        return fov / Zoomify.getZoomDivisor(MinecraftClient.getInstance().getTickDelta());
+    @Inject(method = "getFov", at = @At(value = "RETURN", shift = At.Shift.BY), locals = LocalCapture.CAPTURE_FAILSOFT, cancellable = true)
+    private void getFov(Camera camera, float tickDelta, boolean changingFov, CallbackInfoReturnable<Double> cir) {
+        cir.setReturnValue(cir.getReturnValueD() / Zoomify.getZoomDivisor(tickDelta));
     }
 }

--- a/src/main/kotlin/dev/isxander/zoomify/zoom/SingleZoomHelper.kt
+++ b/src/main/kotlin/dev/isxander/zoomify/zoom/SingleZoomHelper.kt
@@ -20,10 +20,10 @@ open class SingleZoomHelper(private val _initialZoom: () -> Double, zoomSpeed: (
         if (transition == TransitionType.INSTANT) {
             interpolation = targetZoom
         } else if (targetZoom > interpolation) {
-            interpolation += zoomSpeed / 20 * tickDelta
+            interpolation += zoomSpeed / 20 * 0.05 + tickDelta
             interpolation = interpolation.coerceAtMost(targetZoom)
         } else if (targetZoom < interpolation) {
-            interpolation -= zoomSpeed / 20 * tickDelta
+            interpolation -= zoomSpeed / 20 * 0.05 + tickDelta
             interpolation = interpolation.coerceAtLeast(targetZoom)
 
             if (ZoomifySettings.zoomOppositeTransitionOut)

--- a/src/main/kotlin/dev/isxander/zoomify/zoom/SingleZoomHelper.kt
+++ b/src/main/kotlin/dev/isxander/zoomify/zoom/SingleZoomHelper.kt
@@ -20,10 +20,10 @@ open class SingleZoomHelper(private val _initialZoom: () -> Double, zoomSpeed: (
         if (transition == TransitionType.INSTANT) {
             interpolation = targetZoom
         } else if (targetZoom > interpolation) {
-            interpolation += zoomSpeed / 20 * 0.05 + tickDelta
+            interpolation += zoomSpeed / 20 * tickDelta
             interpolation = interpolation.coerceAtMost(targetZoom)
         } else if (targetZoom < interpolation) {
-            interpolation -= zoomSpeed / 20 * 0.05 + tickDelta
+            interpolation -= zoomSpeed / 20 * tickDelta
             interpolation = interpolation.coerceAtLeast(targetZoom)
 
             if (ZoomifySettings.zoomOppositeTransitionOut)

--- a/src/main/kotlin/dev/isxander/zoomify/zoom/TieredZoomHelper.kt
+++ b/src/main/kotlin/dev/isxander/zoomify/zoom/TieredZoomHelper.kt
@@ -23,10 +23,10 @@ open class TieredZoomHelper(zoomSpeed: () -> Double, transition: () -> Transitio
         if (transition == TransitionType.INSTANT) {
             prevZoomDivisor = targetZoom
         } else if (targetZoom > prevZoomDivisor) {
-            prevZoomDivisor += tickDelta * (zoomSpeed / 20)
+            prevZoomDivisor += zoomSpeed / 20 * tickDelta
             prevZoomDivisor = prevZoomDivisor.coerceAtMost(targetZoom)
         } else if (targetZoom < prevZoomDivisor) {
-            prevZoomDivisor -= tickDelta * (zoomSpeed / 20)
+            prevZoomDivisor -= zoomSpeed / 20 * tickDelta
             prevZoomDivisor = prevZoomDivisor.coerceAtLeast(targetZoom)
 
             if (ZoomifySettings.scrollZoomOppositeTransitionOut)


### PR DESCRIPTION
This fix changes the way interpolation is calculated - switching from ticks to ms. 
Now the animation is less dependent on frame rate and plays normally at any value of the fps counter.

Also correct `tickDelta` is used for correction.

Here's a GIF for comparison (without and with):
![without](https://user-images.githubusercontent.com/90945793/169664025-52fdf260-8787-489f-a919-3c5fa2e0f512.gif)
![with](https://user-images.githubusercontent.com/90945793/169664114-5120411c-7769-4747-a547-48d77d59e254.gif)

