### PR TITLE
Updated to 1.20.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     alias(libs.plugins.kotlin.plugin.serialization)
 
     alias(libs.plugins.loom)
-    alias(libs.plugins.loom.vineflower)
 
     id("com.modrinth.minotaur") version "2.7.+"
     id("me.hypherionmc.cursegradle") version "2.+"
@@ -15,7 +14,7 @@ plugins {
 }
 
 group = "dev.isxander"
-version = "2.11.2"
+version = "2.12.0"
 
 repositories {
     mavenCentral()
@@ -104,7 +103,7 @@ if (modrinthId.isNotEmpty()) {
         versionNumber.set("${project.version}")
         versionType.set("release")
         uploadFile.set(tasks["remapJar"])
-        gameVersions.set(listOf("1.20", "1.20.1"))
+        gameVersions.set(listOf("1.20.2"))
         loaders.set(listOf("fabric", "quilt"))
         changelog.set(changelogText)
         syncBodyFrom.set(file("README.md").readText())
@@ -128,8 +127,7 @@ if (hasProperty("curseforge.token") && curseforgeId.isNotEmpty()) {
 
             id = curseforgeId
             releaseType = "release"
-            addGameVersion("1.20")
-            addGameVersion("1.20.1")
+            addGameVersion("1.20.2")
             addGameVersion("Fabric")
             addGameVersion("Quilt")
             addGameVersion("Java 17")
@@ -159,7 +157,7 @@ githubRelease {
     owner(split[0])
     repo(split[1])
     tagName("${project.version}")
-    targetCommitish("1.20")
+    targetCommitish("1.20.2")
     body(changelogText)
     releaseAssets(tasks["remapJar"].outputs.files)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,20 @@
 [versions]
-kotlin = "1.9.0"
-loom = "1.3.+"
-loom_vineflower = "1.11.+"
+kotlin = "1.9.10"
+loom = "1.4.+"
 
-minecraft = "1.20.1"
-fabric_loader = "0.14.21"
-quilt_mappings = "23"
+minecraft = "1.20.2"
+fabric_loader = "0.14.22"
+quilt_mappings = "2"
 
-fabric_api = "0.86.1+1.20.1"
-fabric_language_kotlin = "1.10.8+kotlin.1.9.0"
-ktoml = "0.4.1"
-yet_another_config_lib = "3.1.1+1.20"
-mod_menu = "7.0.0"
-mixin_extras = "0.2.0-beta.9"
+fabric_api = "0.89.2+1.20.2"
+fabric_language_kotlin = "1.10.10+kotlin.1.9.10"
+ktoml = "0.5.0"
+yet_another_config_lib = "3.2.0+1.20.2"
+mod_menu = "8.0.0-beta.2"
+mixin_extras = "0.2.0-rc.5"
 controlify = "1.6.0+1.20"
 
-settxi = "2.10.6"
+settxi = "2.11.0"
 
 [libraries]
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
@@ -42,7 +41,6 @@ kotlin_jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin_plugin_serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 loom = { id = "fabric-loom", version.ref = "loom" }
-loom_vineflower = { id = "io.github.juuxel.loom-vineflower", version.ref = "loom_vineflower" }
 
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/dev/isxander/zoomify/mixins/zoom/MouseMixin.java
+++ b/src/main/java/dev/isxander/zoomify/mixins/zoom/MouseMixin.java
@@ -15,16 +15,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MouseHandler.class)
 public class MouseMixin {
-    @Shadow private double accumulatedScroll;
+    @Shadow private double accumulatedScrollY;
 
     @Inject(
         method = "onScroll",
-        at = @At(value = "FIELD", target = "Lnet/minecraft/client/MouseHandler;accumulatedScroll:D", ordinal = 7),
+        at = @At(value = "FIELD", target = "Lnet/minecraft/client/MouseHandler;accumulatedScrollX:D", ordinal = 7),
         cancellable = true
     )
     private void scrollStepCounter(CallbackInfo ci) {
-        if (ZoomifySettings.INSTANCE.getScrollZoom() && Zoomify.INSTANCE.getZooming() && accumulatedScroll != 0 && !ZoomifySettings.INSTANCE.getKeybindScrolling()) {
-            Zoomify.mouseZoom(accumulatedScroll);
+        if (ZoomifySettings.INSTANCE.getScrollZoom() && Zoomify.INSTANCE.getZooming() && accumulatedScrollY != 0 && !ZoomifySettings.INSTANCE.getKeybindScrolling()) {
+            Zoomify.mouseZoom(accumulatedScrollY);
             ci.cancel();
         }
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -43,14 +43,14 @@
   ],
   "depends": {
     "fabric-api": "*",
-    "fabricloader": ">=0.14.21",
-    "fabric-language-kotlin": ">=1.10.8+kotlin.1.9.0",
-    "minecraft": "1.20.x",
+    "fabricloader": ">=0.14.22",
+    "fabric-language-kotlin": ">=1.10.10+kotlin.1.9.10",
+    "minecraft": ">=1.20.2",
     "java": ">=17",
     "yet_another_config_lib_v3": ">=3.1.1+1.20"
   },
   "suggests": {
-    "modmenu": ">=4.0.0"
+    "modmenu": ">=8.0.0"
   },
   "breaks": {
     "optifabric": "*"


### PR DESCRIPTION
Updated to 1.20.2, here's the changes:

- Increased minor version to 12
- Updated libs.versions.toml
- Removed vineflower as it's handled by loom now
- Updated gradle to 8.3
- Updated version for modrinth, curseforge and github releases (Need a second check, never did this)
- Fixed MouseMixin